### PR TITLE
[Optimize]: 🚀 Reduce the mirror image size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY internal/ internal/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o bin/llm-d-routing-sidecar cmd/cmd.go
 
-FROM registry.access.redhat.com/ubi9/ubi:latest
+FROM gcr.io/distroless/static-debian12:latest
 WORKDIR /
 COPY --from=builder /workspace/bin/llm-d-routing-sidecar /app/llm-d-routing-sidecar
 USER 65532:65532


### PR DESCRIPTION
Before：
```
ghcr.io/llm-d/llm-d-routing-sidecar                 0.0.7                           219MB
```

After:
```
ghcr.io/llm-d/llm-d-routing-sidecar                 0.0.1-small-image                11.8MB
```
