### PR TITLE
proxy: Update error message when vllm is not ready

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -140,7 +140,7 @@ func (s *Server) createRoutes() *http.ServeMux {
 
 	// Passthrough decoder handler
 	decoderProxy := httputil.NewSingleHostReverseProxy(s.decoderURL)
-	decoderProxy.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
+	decoderProxy.ErrorHandler = func(res http.ResponseWriter, _ *http.Request, err error) {
 
 		// Log errors from the decoder proxy
 		switch {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -18,11 +18,13 @@ package proxy
 
 import (
 	"context"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -137,7 +139,19 @@ func (s *Server) createRoutes() *http.ServeMux {
 	mux.HandleFunc("POST "+CompletionsPath, s.chatCompletionsHandler)     // /v1/completions (legacy)
 
 	// Passthrough decoder handler
-	s.decoderProxy = httputil.NewSingleHostReverseProxy(s.decoderURL)
+	decoderProxy := httputil.NewSingleHostReverseProxy(s.decoderURL)
+	decoderProxy.ErrorHandler = func(res http.ResponseWriter, req *http.Request, err error) {
+
+		// Log errors from the decoder proxy
+		switch {
+		case errors.Is(err, syscall.ECONNREFUSED):
+			s.logger.Error(err, "waiting for vLLM to be ready")
+		default:
+			s.logger.Error(err, "http: proxy error")
+		}
+		res.WriteHeader(http.StatusBadGateway)
+	}
+	s.decoderProxy = decoderProxy
 	mux.Handle("/", s.decoderProxy)
 
 	return mux


### PR DESCRIPTION
Updates the error message returned when vllm is not yet ready.

Previously, would print connection refused messages:
```
2025/05/11 18:27:43 http: proxy error: dial tcp [::1]:8200: connect: connection refused
```

But now prints more details:
```
E0709 10:50:42.153947   75821 proxy.go:148] "waiting for vLLM to be ready" err="dial tcp [::1]:8001: connect: connection refused" logger="proxy server"
```

Fixes #12 