### PR TITLE
sanity check target decode host

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,4 +27,6 @@ require (
 	golang.org/x/tools v0.31.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apimachinery v0.33.3 // indirect
+	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -51,5 +51,9 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/apimachinery v0.33.3 h1:4ZSrmNa0c/ZpZJhAgRdcsFcZOw1PQU1bALVQ0B3I5LA=
+k8s.io/apimachinery v0.33.3/go.mod h1:BHW0YOu7n22fFv/JkYOEfkUYNRN0fj0BlvMFWA7b+SM=
 k8s.io/klog/v2 v2.130.1 h1:n9Xl7H1Xvksem4KFG4PYbdQCQxqc/tTUyrgXaOhHSzk=
 k8s.io/klog/v2 v2.130.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
+k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -180,7 +180,8 @@ func (s *Server) prefillerProxyHandler(hostPort string) (http.Handler, error) {
 	if err != nil {
 		s.logger.Error(err, "failed to parse URL", "hostPort", hostPort)
 		return nil, err
-	} else if err := validateTarget(u.Hostname()); err != nil {
+	}
+	if err := validateTarget(u.Hostname()); err != nil {
 		s.logger.Error(err, "invalid target", "hostPort", hostPort)
 		return nil, err
 	}


### PR DESCRIPTION
Following llm-d/llm-d-inference-scheduler#244 when a user sets the prefill header value, EPP would replaces it with an invalid host target (e.g., an empty string or invalid host name. Unfortunately EPP can not remove the header completely). 
This would result in a successful URL parse but invalid host in URL. Added function to do some sanity check on the resulting host in URL and return an error when invalid.